### PR TITLE
Feat/登録するもののカテゴリ分け #18

### DIFF
--- a/lib/core/addtask/addtask.dart
+++ b/lib/core/addtask/addtask.dart
@@ -21,6 +21,7 @@ class _AddTaskWidgetState extends State<AddTaskWidget> {
   final TextEditingController _titleController = TextEditingController();
   final TextEditingController _descriptionController = TextEditingController();
   DateTime _selectedDate = DateTime.now();
+  TaskCategory _selectedCategory = TaskCategory.task;
 
   @override
   void initState() {
@@ -43,13 +44,17 @@ class _AddTaskWidgetState extends State<AddTaskWidget> {
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: const Color(0xFFECE6F0),
+        color: Colors.white,
         borderRadius: BorderRadius.circular(28),
+        border: Border.all(
+          color: const Color(0xFF6750A4).withValues(alpha: 0.4),
+          width: 2,
+        ),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
-            blurRadius: 10,
-            offset: const Offset(0, 4),
+            color: const Color(0xFF6750A4).withValues(alpha: 0.15),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
           ),
         ],
       ),
@@ -58,61 +63,215 @@ class _AddTaskWidgetState extends State<AddTaskWidget> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // タイトル
-          const Text(
-            '新規タスク登録',
-            style: TextStyle(
-              color: Color(0xFF49454F),
-              fontSize: 20,
-              fontFamily: 'Roboto',
-              fontWeight: FontWeight.bold,
-              letterSpacing: 0.10,
-            ),
+          const Row(
+            children: [
+              Icon(
+                Icons.add_task,
+                color: Color(0xFF6750A4),
+                size: 24,
+              ),
+              SizedBox(width: 8),
+              Text(
+                '新規タスク登録',
+                style: TextStyle(
+                  color: Color(0xFF6750A4),
+                  fontSize: 20,
+                  fontFamily: 'Roboto',
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 0.10,
+                ),
+              ),
+            ],
           ),
           const SizedBox(height: 24),
 
           // タスク名入力
-          TextField(
-            controller: _titleController,
-            decoration: const InputDecoration(
-              labelText: 'タスク名',
-              hintText: 'タスク名を入力してください',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Icons.task, color: Color(0xFF6750A4)),
+          Container(
+            decoration: BoxDecoration(
+              color: const Color(0xFF6750A4).withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
             ),
-            style: const TextStyle(fontSize: 16),
+            child: TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: 'タスク名',
+                hintText: 'タスク名を入力してください',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.task, color: Color(0xFF6750A4)),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: Color(0xFF6750A4), width: 2),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: Color(0xFF6750A4)),
+                ),
+                labelStyle: TextStyle(color: Color(0xFF6750A4)),
+                fillColor: Colors.white,
+                filled: true,
+              ),
+              style: const TextStyle(fontSize: 16),
+            ),
           ),
           const SizedBox(height: 16),
 
           // 日付選択
-          InkWell(
-            onTap: () => _selectDate(context),
-            child: InputDecorator(
-              decoration: const InputDecoration(
-                labelText: '日付',
-                border: OutlineInputBorder(),
-                prefixIcon: Icon(Icons.calendar_today, color: Color(0xFF6750A4)),
-              ),
-              child: Text(
-                '${_selectedDate.year}/${_selectedDate.month.toString().padLeft(2, '0')}/${_selectedDate.day.toString().padLeft(2, '0')}',
-                style: const TextStyle(fontSize: 16),
+          Container(
+            decoration: BoxDecoration(
+              color: const Color(0xFF6750A4).withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: InkWell(
+              onTap: () => _selectDate(context),
+              borderRadius: BorderRadius.circular(8),
+              child: InputDecorator(
+                decoration: const InputDecoration(
+                  labelText: '日付',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.calendar_today, color: Color(0xFF6750A4)),
+                  focusedBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Color(0xFF6750A4), width: 2),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderSide: BorderSide(color: Color(0xFF6750A4)),
+                  ),
+                  labelStyle: TextStyle(color: Color(0xFF6750A4)),
+                  fillColor: Colors.white,
+                  filled: true,
+                ),
+                child: Text(
+                  '${_selectedDate.year}/${_selectedDate.month.toString().padLeft(2, '0')}/${_selectedDate.day.toString().padLeft(2, '0')}',
+                  style: const TextStyle(fontSize: 16),
+                ),
               ),
             ),
           ),
           const SizedBox(height: 16),
 
-
+          // カテゴリ選択
+          Container(
+            decoration: BoxDecoration(
+              color: _selectedCategory.lightColor.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: DropdownButtonFormField<TaskCategory>(
+              value: _selectedCategory,
+              decoration: InputDecoration(
+                labelText: 'カテゴリ',
+                border: const OutlineInputBorder(),
+                prefixIcon: Icon(_selectedCategory.icon, color: _selectedCategory.color),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: _selectedCategory.color, width: 2),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: _selectedCategory.color),
+                ),
+                labelStyle: TextStyle(color: _selectedCategory.color),
+                fillColor: Colors.white,
+                filled: true,
+              ),
+              dropdownColor: Colors.white,
+              selectedItemBuilder: (BuildContext context) {
+                return TaskCategory.values.map((TaskCategory category) {
+                  return Row(
+                    children: [
+                      Text(
+                        category.displayName,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                          color: category.color,
+                        ),
+                      ),
+                    ],
+                  );
+                }).toList();
+              },
+              items: TaskCategory.values.map((TaskCategory category) {
+                return DropdownMenuItem<TaskCategory>(
+                  value: category,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Row(
+                      children: [
+                        Icon(
+                          category.icon,
+                          color: category.color,
+                          size: 20,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                category.displayName,
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 14,
+                                  color: category.color,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                category.description,
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  color: Colors.grey[600],
+                                  height: 1.2,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }).toList(),
+              onChanged: (TaskCategory? newValue) {
+                if (newValue != null) {
+                  setState(() {
+                    _selectedCategory = newValue;
+                  });
+                }
+              },
+              isExpanded: true,
+              icon: Icon(
+                Icons.arrow_drop_down,
+                color: _selectedCategory.color,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
 
           // 詳細入力
-          TextField(
-            controller: _descriptionController,
-            decoration: const InputDecoration(
-              labelText: '詳細・メモ',
-              hintText: '詳細を入力してください（任意）',
-              border: OutlineInputBorder(),
-              prefixIcon: Icon(Icons.note, color: Color(0xFF6750A4)),
+          Container(
+            decoration: BoxDecoration(
+              color: const Color(0xFF6750A4).withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
             ),
-            maxLines: 3,
-            style: const TextStyle(fontSize: 16),
+            child: TextField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: '詳細・メモ',
+                hintText: '詳細を入力してください（任意）',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.note, color: Color(0xFF6750A4)),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: Color(0xFF6750A4), width: 2),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: Color(0xFF6750A4)),
+                ),
+                labelStyle: TextStyle(color: Color(0xFF6750A4)),
+                fillColor: Colors.white,
+                filled: true,
+              ),
+              maxLines: 3,
+              style: const TextStyle(fontSize: 16),
+            ),
           ),
           const SizedBox(height: 16),
 
@@ -180,6 +339,7 @@ class _AddTaskWidgetState extends State<AddTaskWidget> {
       _titleController.clear();
       _descriptionController.clear();
       _selectedDate = widget.initialDate ?? DateTime.now();
+      _selectedCategory = TaskCategory.task;
     });
   }
 
@@ -201,6 +361,7 @@ class _AddTaskWidgetState extends State<AddTaskWidget> {
         description: _descriptionController.text.trim().isEmpty 
             ? null 
             : _descriptionController.text.trim(),
+        category: _selectedCategory,
       );
 
       // Hiveストレージに保存

--- a/lib/core/models/task_data.dart
+++ b/lib/core/models/task_data.dart
@@ -1,7 +1,97 @@
 import 'dart:typed_data';
 import 'package:hive/hive.dart';
+import 'package:flutter/material.dart';
 
 part 'task_data.g.dart';
+
+@HiveType(typeId: 1)
+enum TaskCategory {
+  @HiveField(0)
+  task, // タスク追加(自発的に行動しないと消化されないもの)
+  
+  @HiveField(1)
+  event, // イベント(決まった時間に行動を起こす必要があるもの)
+  
+  @HiveField(2)
+  period, // 期間(自発的な行動を起こす必要はないが、生活になんらかの変化がある)
+  
+  @HiveField(3)
+  repeat, // 繰り返し(特定の周期ごとに行う)
+  
+  @HiveField(4)
+  goal, // ゴール(超長期的な目標、複数のタスクを完了することで完了できるもの)
+}
+
+extension TaskCategoryExtension on TaskCategory {
+  /// カテゴリー名を日本語で取得
+  String get displayName {
+    switch (this) {
+      case TaskCategory.task:
+        return 'タスク';
+      case TaskCategory.event:
+        return 'イベント';
+      case TaskCategory.period:
+        return '期間';
+      case TaskCategory.repeat:
+        return '繰り返し';
+      case TaskCategory.goal:
+        return 'ゴール';
+    }
+  }
+  
+  /// カテゴリー説明を取得
+  String get description {
+    switch (this) {
+      case TaskCategory.task:
+        return '自発的に行動しないと消化されないもの\n例: レポート作成、掃除、買い物';
+      case TaskCategory.event:
+        return '決まった時間に行動を起こす必要があるもの\n例: ミーティング、友達と遊びに行く';
+      case TaskCategory.period:
+        return '一定の期間中、生活になんらかの変化がある\n例: 夏休み、旅行';
+      case TaskCategory.repeat:
+        return '特定の周期ごとに行うもの\n例: 毎週木曜日にゴミ出し、毎月末に報告書を作成する';
+      case TaskCategory.goal:
+        return '超長期的な目標、複数のタスクを完了することで完了できるもの\n例: 東京大学に合格、10Kg痩せる、簿記3級を取得する';
+    }
+  }
+  
+  /// カテゴリー別の色を取得
+  Color get color {
+    switch (this) {
+      case TaskCategory.task:
+        return const Color(0xFF6750A4); // パープル
+      case TaskCategory.event:
+        return const Color(0xFF1976D2); // ブルー
+      case TaskCategory.period:
+        return const Color(0xFF388E3C); // グリーン
+      case TaskCategory.repeat:
+        return const Color(0xFFF57C00); // オレンジ
+      case TaskCategory.goal:
+        return const Color(0xFFD32F2F); // レッド
+    }
+  }
+  
+  /// カテゴリー別の淡い色を取得（背景用）
+  Color get lightColor {
+    return color.withValues(alpha: 0.1);
+  }
+  
+  /// カテゴリー別のアイコンを取得
+  IconData get icon {
+    switch (this) {
+      case TaskCategory.task:
+        return Icons.assignment;
+      case TaskCategory.event:
+        return Icons.event;
+      case TaskCategory.period:
+        return Icons.schedule;
+      case TaskCategory.repeat:
+        return Icons.repeat;
+      case TaskCategory.goal:
+        return Icons.flag;
+    }
+  }
+}
 
 @HiveType(typeId: 0)
 class TaskData extends HiveObject {
@@ -29,6 +119,9 @@ class TaskData extends HiveObject {
   @HiveField(7)
   String? sentence2;
 
+  @HiveField(8)
+  TaskCategory category;
+
   TaskData({
     required this.id,
     required this.task,
@@ -38,6 +131,7 @@ class TaskData extends HiveObject {
     this.image2,
     this.sentence1,
     this.sentence2,
+    this.category = TaskCategory.task, // デフォルトはタスク
   });
 
   /// image1データが存在するかチェック
@@ -158,8 +252,38 @@ class TaskData extends HiveObject {
     return '${due.year}/${due.month.toString().padLeft(2, '0')}/${due.day.toString().padLeft(2, '0')}';
   }
 
+  /// カテゴリー名を取得
+  String getCategoryDisplayName() {
+    return category.displayName;
+  }
+
+  /// カテゴリーの色を取得
+  Color getCategoryColor() {
+    return category.color;
+  }
+
+  /// カテゴリーの淡い色を取得
+  Color getCategoryLightColor() {
+    return category.lightColor;
+  }
+
+  /// カテゴリーのアイコンを取得
+  IconData getCategoryIcon() {
+    return category.icon;
+  }
+
+  /// カテゴリーの説明を取得
+  String getCategoryDescription() {
+    return category.description;
+  }
+
+  /// 指定したカテゴリーかどうかをチェック
+  bool isCategory(TaskCategory targetCategory) {
+    return category == targetCategory;
+  }
+
   @override
   String toString() {
-    return 'TaskData{id: $id, task: $task, due: $due, image1: ${getImage1Size()} bytes, image2: ${getImage2Size()} bytes, description: ${description ?? "null"}, sentence1: ${sentence1 ?? "null"}, sentence2: ${sentence2 ?? "null"}}';
+    return 'TaskData{id: $id, task: $task, due: $due, category: ${category.displayName}, image1: ${getImage1Size()} bytes, image2: ${getImage2Size()} bytes, description: ${description ?? "null"}, sentence1: ${sentence1 ?? "null"}, sentence2: ${sentence2 ?? "null"}}';
   }
 }

--- a/lib/core/models/task_data.g.dart
+++ b/lib/core/models/task_data.g.dart
@@ -25,13 +25,14 @@ class TaskDataAdapter extends TypeAdapter<TaskData> {
       image2: fields[5] as Uint8List?,
       sentence1: fields[6] as String?,
       sentence2: fields[7] as String?,
+      category: fields[8] as TaskCategory,
     );
   }
 
   @override
   void write(BinaryWriter writer, TaskData obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -47,7 +48,9 @@ class TaskDataAdapter extends TypeAdapter<TaskData> {
       ..writeByte(6)
       ..write(obj.sentence1)
       ..writeByte(7)
-      ..write(obj.sentence2);
+      ..write(obj.sentence2)
+      ..writeByte(8)
+      ..write(obj.category);
   }
 
   @override
@@ -57,6 +60,60 @@ class TaskDataAdapter extends TypeAdapter<TaskData> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is TaskDataAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class TaskCategoryAdapter extends TypeAdapter<TaskCategory> {
+  @override
+  final int typeId = 1;
+
+  @override
+  TaskCategory read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return TaskCategory.task;
+      case 1:
+        return TaskCategory.event;
+      case 2:
+        return TaskCategory.period;
+      case 3:
+        return TaskCategory.repeat;
+      case 4:
+        return TaskCategory.goal;
+      default:
+        return TaskCategory.task;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, TaskCategory obj) {
+    switch (obj) {
+      case TaskCategory.task:
+        writer.writeByte(0);
+        break;
+      case TaskCategory.event:
+        writer.writeByte(1);
+        break;
+      case TaskCategory.period:
+        writer.writeByte(2);
+        break;
+      case TaskCategory.repeat:
+        writer.writeByte(3);
+        break;
+      case TaskCategory.goal:
+        writer.writeByte(4);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TaskCategoryAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/core/services/generic_hive_storage.dart
+++ b/lib/core/services/generic_hive_storage.dart
@@ -6,21 +6,32 @@ class GenericHiveStorage<T extends HiveObject> {
   final String boxName;
   final int typeId;
   final TypeAdapter<T> adapter;
+  final List<TypeAdapter>? additionalAdapters;
   Box<T>? _box;
 
   GenericHiveStorage({
     required this.boxName,
     required this.typeId,
     required this.adapter,
+    this.additionalAdapters,
   });
 
   /// Hiveを初期化し、ボックスを開く
   Future<void> init() async {
     await Hive.initFlutter();
 
-    // アダプターを登録
+    // メインアダプターを登録
     if (!Hive.isAdapterRegistered(typeId)) {
       Hive.registerAdapter(adapter);
+    }
+
+    // 追加アダプターを登録
+    if (additionalAdapters != null) {
+      for (final additionalAdapter in additionalAdapters!) {
+        if (!Hive.isAdapterRegistered(additionalAdapter.typeId)) {
+          Hive.registerAdapter(additionalAdapter);
+        }
+      }
     }
 
     // ボックスを開く

--- a/lib/feat/edit/task_edit.dart
+++ b/lib/feat/edit/task_edit.dart
@@ -22,6 +22,7 @@ class _TaskEditState extends State<TaskEdit> {
   TaskData? _currentTask;
   bool _isLoading = true;
   DateTime _selectedDueDate = DateTime.now().add(const Duration(days: 1));
+  TaskCategory _selectedCategory = TaskCategory.task;
 
   @override
   void initState() {
@@ -37,6 +38,7 @@ class _TaskEditState extends State<TaskEdit> {
         _taskNameController.text = _currentTask!.task;
         _detailsController.text = _currentTask!.description ?? '';
         _selectedDueDate = _currentTask!.due;
+        _selectedCategory = _currentTask!.category;
       }
     } else {
       // 新規タスクの場合はデフォルト値を設定
@@ -123,6 +125,10 @@ class _TaskEditState extends State<TaskEdit> {
               ),
               const SizedBox(height: 16),
 
+              // カテゴリ選択セクション
+              _buildCategorySection(),
+              const SizedBox(height: 16),
+
               // 詳細セクション
               DetailsSection(controller: _detailsController),
               const SizedBox(height: 28),
@@ -141,7 +147,7 @@ class _TaskEditState extends State<TaskEdit> {
           color: Colors.white,
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.1),
+              color: Colors.black.withValues(alpha: 0.1),
               blurRadius: 4,
               offset: const Offset(0, -2),
             ),
@@ -174,6 +180,147 @@ class _TaskEditState extends State<TaskEdit> {
     );
   }
 
+  Widget _buildCategorySection() {
+    return Container(
+      decoration: BoxDecoration(
+        color: _selectedCategory.lightColor.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: _selectedCategory.color.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ヘッダー
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: _selectedCategory.lightColor.withValues(alpha: 0.2),
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(12),
+                topRight: Radius.circular(12),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.category,
+                  color: _selectedCategory.color,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'カテゴリ',
+                  style: TextStyle(
+                    color: _selectedCategory.color,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // ドロップダウン
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: DropdownButtonFormField<TaskCategory>(
+              value: _selectedCategory,
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                prefixIcon: Icon(_selectedCategory.icon, color: _selectedCategory.color),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: _selectedCategory.color, width: 2),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: _selectedCategory.color),
+                ),
+                fillColor: Colors.white,
+                filled: true,
+              ),
+              dropdownColor: Colors.white,
+              selectedItemBuilder: (BuildContext context) {
+                return TaskCategory.values.map((TaskCategory category) {
+                  return Row(
+                    children: [
+                      Text(
+                        category.displayName,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                          color: category.color,
+                        ),
+                      ),
+                    ],
+                  );
+                }).toList();
+              },
+              items: TaskCategory.values.map((TaskCategory category) {
+                return DropdownMenuItem<TaskCategory>(
+                  value: category,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Row(
+                      children: [
+                        Icon(
+                          category.icon,
+                          color: category.color,
+                          size: 20,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                category.displayName,
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 14,
+                                  color: category.color,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                category.description,
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  color: Colors.grey[600],
+                                  height: 1.2,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }).toList(),
+              onChanged: (TaskCategory? newValue) {
+                if (newValue != null) {
+                  setState(() {
+                    _selectedCategory = newValue;
+                  });
+                }
+              },
+              isExpanded: true,
+              icon: Icon(
+                Icons.arrow_drop_down,
+                color: _selectedCategory.color,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _saveTask() async {
     if (widget.taskId != null && _currentTask != null) {
       // 既存タスクを更新
@@ -188,6 +335,7 @@ class _TaskEditState extends State<TaskEdit> {
         image2: _currentTask!.image2, // 既存の画像データを保持
         sentence1: _currentTask!.sentence1, // 既存のsentence1データを保持
         sentence2: _currentTask!.sentence2, // 既存のsentence2データを保持
+        category: _selectedCategory, // カテゴリ情報を更新
       );
 
       await TaskStorage.updateTask(updatedTask);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -388,10 +388,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
Closes #18 
登録するものを5つのカテゴリに分け、それぞれ独自の色で表示するようにした。
(タスク、イベント、期間、繰り返し、ゴール)
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2025-08-29 at 21 12 58" src="https://github.com/user-attachments/assets/59c09691-cd3f-4b0e-8a94-c40e7f0d5fce" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2025-08-29 at 21 13 04" src="https://github.com/user-attachments/assets/09bcb3f2-88c3-4dcb-b413-128228ef007f" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2025-08-29 at 21 13 09" src="https://github.com/user-attachments/assets/d3a3abaa-b139-4564-b6a0-727334781d37" />
