### PR TITLE
Feat/バッジ機能の実装

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,20 +3,32 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - share_plus (0.0.1):
+    - Flutter
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  share_plus: 4dfe6f47fc3248e89b3eea0be59a95d0433ebe1a
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
 

--- a/lib/core/models/task_data.dart
+++ b/lib/core/models/task_data.dart
@@ -125,6 +125,15 @@ class TaskData extends HiveObject {
   @HiveField(9)
   bool isCompleted;
 
+  @HiveField(10)
+  String? badgeTitle;
+
+  @HiveField(11)
+  String? badgeText;
+
+  @HiveField(12)
+  Uint8List? badgeImage;
+
   TaskData({
     required this.id,
     required this.task,
@@ -136,6 +145,9 @@ class TaskData extends HiveObject {
     this.sentence2,
     this.category = TaskCategory.task, // デフォルトはタスク
     this.isCompleted = false, // デフォルトは未完了
+    this.badgeTitle,
+    this.badgeText,
+    this.badgeImage,
   });
 
   /// image1データが存在するかチェック
@@ -201,6 +213,31 @@ class TaskData extends HiveObject {
   /// sentence2の長さを取得（存在しない場合は0）
   int getSentence2Length() {
     return sentence2?.length ?? 0;
+  }
+
+  /// バッジタイトルが存在するかチェック
+  bool hasBadgeTitle() {
+    return badgeTitle != null && badgeTitle!.isNotEmpty;
+  }
+
+  /// バッジテキストが存在するかチェック
+  bool hasBadgeText() {
+    return badgeText != null && badgeText!.isNotEmpty;
+  }
+
+  /// バッジ画像が存在するかチェック
+  bool hasBadgeImage() {
+    return badgeImage != null;
+  }
+
+  /// バッジデータが完全に存在するかチェック
+  bool hasBadgeData() {
+    return hasBadgeTitle() && hasBadgeText() && hasBadgeImage();
+  }
+
+  /// バッジ画像のサイズを取得（存在しない場合は0）
+  int getBadgeImageSize() {
+    return badgeImage?.length ?? 0;
   }
 
   /// description以外の4つのフィールド（image1、image2、sentence1、sentence2）のいずれかがnullの場合trueを返す
@@ -315,6 +352,6 @@ class TaskData extends HiveObject {
 
   @override
   String toString() {
-    return 'TaskData{id: $id, task: $task, due: $due, category: ${category.displayName}, isCompleted: $isCompleted, image1: ${getImage1Size()} bytes, image2: ${getImage2Size()} bytes, description: ${description ?? "null"}, sentence1: ${sentence1 ?? "null"}, sentence2: ${sentence2 ?? "null"}}';
+    return 'TaskData{id: $id, task: $task, due: $due, category: ${category.displayName}, isCompleted: $isCompleted, image1: ${getImage1Size()} bytes, image2: ${getImage2Size()} bytes, description: ${description ?? "null"}, sentence1: ${sentence1 ?? "null"}, sentence2: ${sentence2 ?? "null"}, badgeTitle: ${badgeTitle ?? "null"}, badgeText: ${badgeText ?? "null"}, badgeImage: ${getBadgeImageSize()} bytes}';
   }
 }

--- a/lib/core/models/task_data.g.dart
+++ b/lib/core/models/task_data.g.dart
@@ -27,13 +27,16 @@ class TaskDataAdapter extends TypeAdapter<TaskData> {
       sentence2: fields[7] as String?,
       category: fields[8] as TaskCategory,
       isCompleted: fields[9] as bool,
+      badgeTitle: fields[10] as String?,
+      badgeText: fields[11] as String?,
+      badgeImage: fields[12] as Uint8List?,
     );
   }
 
   @override
   void write(BinaryWriter writer, TaskData obj) {
     writer
-      ..writeByte(10)
+      ..writeByte(13)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -53,7 +56,13 @@ class TaskDataAdapter extends TypeAdapter<TaskData> {
       ..writeByte(8)
       ..write(obj.category)
       ..writeByte(9)
-      ..write(obj.isCompleted);
+      ..write(obj.isCompleted)
+      ..writeByte(10)
+      ..write(obj.badgeTitle)
+      ..writeByte(11)
+      ..write(obj.badgeText)
+      ..writeByte(12)
+      ..write(obj.badgeImage);
   }
 
   @override

--- a/lib/core/services/badge_service.dart
+++ b/lib/core/services/badge_service.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:http/http.dart' as http;
+import '../models/task_data.dart';
+import '../config/api_config.dart';
+import 'task_storage.dart';
+
+class BadgeService {
+  /// バッジデータを取得（キャッシュを優先し、なければAPIから取得してDBに保存）
+  static Future<BadgeResponse> fetchBadge(List<TaskData> tasks) async {
+    if (tasks.isEmpty) {
+      throw Exception('タスクが指定されていません');
+    }
+
+    final task = tasks.first; // 最初のタスクを使用
+    
+    // まずDBに保存されたバッジデータがあるかチェック
+    if (task.hasBadgeData()) {
+      print('Using cached badge data for task ${task.id}');
+      return BadgeResponse(
+        name: task.badgeTitle!,
+        text: task.badgeText!,
+        imageBase64: '', // キャッシュからは不要
+        imageData: task.badgeImage!,
+      );
+    }
+
+    // キャッシュされたデータがない場合はAPIから取得
+    print('Fetching new badge data from API for task ${task.id}');
+    return await _fetchBadgeFromAPI(tasks);
+  }
+
+  /// APIからバッジデータを取得してDBに保存
+  static Future<BadgeResponse> _fetchBadgeFromAPI(List<TaskData> tasks) async {
+    try {
+      // タスクデータをAPI用の形式に変換
+      final List<Map<String, dynamic>> taskList = tasks
+          .map((task) => {'id': task.id, 'contents': task.task})
+          .toList();
+
+      // リクエストボディ
+      final Map<String, dynamic> requestBody = {
+        'tasks': taskList,
+      };
+
+      // バッジAPIのURLを構築
+      final badgeUrl = ApiConfig.baseUrl.replaceAll('/dialy', '/badge');
+      print('Badge API URL: $badgeUrl'); // デバッグ用
+      print('Request body: ${jsonEncode(requestBody)}'); // デバッグ用
+
+      // API呼び出し（バッジ生成は時間がかかるため90秒のタイムアウト）
+      final response = await http
+          .post(
+            Uri.parse(badgeUrl),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode(requestBody),
+          )
+          .timeout(const Duration(seconds: 90));
+
+      print('Response status: ${response.statusCode}'); // デバッグ用
+      print('Response headers: ${response.headers}'); // デバッグ用
+
+      if (response.statusCode == 200) {
+        final Map<String, dynamic> responseData = jsonDecode(response.body);
+        final badgeResponse = BadgeResponse.fromJson(responseData);
+
+        // APIから取得したバッジデータをDBに保存
+        await _saveBadgeToDatabase(tasks.first, badgeResponse);
+
+        return badgeResponse;
+      } else {
+        print('Response body: ${response.body}'); // エラー時のレスポンス内容
+        throw Exception('API Error: ${response.statusCode} - ${response.body}');
+      }
+    } on TimeoutException {
+      throw Exception('タイムアウトエラー: サーバーの応答が遅すぎます (90秒)');
+    } catch (e) {
+      print('Badge API Error: $e'); // デバッグ用
+      throw Exception('バッジデータの取得に失敗しました: $e');
+    }
+  }
+
+  /// バッジデータをタスクのDBレコードに保存
+  static Future<void> _saveBadgeToDatabase(TaskData task, BadgeResponse badgeResponse) async {
+    try {
+      // 更新されたタスクデータを作成
+      final updatedTask = TaskData(
+        id: task.id,
+        task: task.task,
+        due: task.due,
+        description: task.description,
+        image1: task.image1,
+        image2: task.image2,
+        sentence1: task.sentence1,
+        sentence2: task.sentence2,
+        category: task.category,
+        isCompleted: task.isCompleted,
+        badgeTitle: badgeResponse.name,
+        badgeText: badgeResponse.text,
+        badgeImage: badgeResponse.imageData,
+      );
+
+      // タスクをストレージに保存
+      await TaskStorage.updateTask(updatedTask);
+      print('Badge data saved to database for task ${task.id}');
+    } catch (e) {
+      print('Failed to save badge data to database: $e');
+      // バッジデータの保存に失敗してもAPIデータは返す
+      rethrow;
+    }
+  }
+}
+
+/// バッジのレスポンスモデル
+class BadgeResponse {
+  final String name;
+  final String text;
+  final String imageBase64;
+  final Uint8List? imageData;
+
+  BadgeResponse({
+    required this.name,
+    required this.text,
+    required this.imageBase64,
+    this.imageData,
+  });
+
+  factory BadgeResponse.fromJson(Map<String, dynamic> json) {
+    final String base64Image = json['image'];
+    Uint8List? imageBytes;
+
+    try {
+      imageBytes = base64Decode(base64Image);
+    } catch (e) {
+      print('Failed to decode base64 badge image: $e');
+    }
+
+    return BadgeResponse(
+      name: json['name'],
+      text: json['text'],
+      imageBase64: base64Image,
+      imageData: imageBytes,
+    );
+  }
+}

--- a/lib/feat/ai_diary/ai_diary.dart
+++ b/lib/feat/ai_diary/ai_diary.dart
@@ -151,7 +151,7 @@ class _AiDiaryState extends State<AiDiary> {
         isLoading = false;
       });
     } catch (e) {
-      setState(() {
+      setState(() { //ここでエラー起きがち、こわい
         errorMessage = e.toString();
         isLoading = false;
       });

--- a/lib/feat/badge/badge.dart
+++ b/lib/feat/badge/badge.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+import '../../core/services/task_storage.dart';
+import '../../core/services/badge_service.dart';
+import '../../core/models/task_data.dart';
+
+// バッジ機能ウィジェット
+class TaskBadge extends StatefulWidget {
+  final int taskId;
+
+  const TaskBadge({
+    super.key,
+    required this.taskId,
+  });
+
+  @override
+  State<TaskBadge> createState() => _TaskBadgeState();
+}
+
+class _TaskBadgeState extends State<TaskBadge> {
+  TaskData? task;
+  BadgeResponse? badgeData;
+  bool isLoading = false;
+  String? errorMessage;
+  bool _disposed = false; // dispose状態を追跡
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTask();
+    _fetchBadgeData();
+  }
+
+  void _loadTask() {
+    if (mounted && !_disposed) {
+      setState(() {
+        task = TaskStorage.getTask(widget.taskId);
+      });
+    }
+  }
+
+  Future<void> _fetchBadgeData() async {
+    if (_disposed) return; // 早期リターンでdispose後の処理を防ぐ
+    
+    if (task == null) {
+      if (mounted && !_disposed) {
+        setState(() {
+          errorMessage = 'タスクが見つかりません';
+          isLoading = false;
+        });
+      }
+      return;
+    }
+
+    if (mounted && !_disposed) {
+      setState(() {
+        isLoading = true;
+        errorMessage = null;
+      });
+    }
+
+    try {
+      final response = await BadgeService.fetchBadge([task!]);
+      
+      // ウィジェットがまだマウントされていて、disposeされていない場合のみsetStateを呼ぶ
+      if (mounted && !_disposed) {
+        setState(() {
+          badgeData = response;
+          isLoading = false;
+        });
+        
+        // バッジデータ取得後、タスクデータを再読み込み（バッジ情報が更新されている可能性があるため）
+        _loadTask();
+      }
+    } catch (e) {
+      // ウィジェットがまだマウントされていて、disposeされていない場合のみsetStateを呼ぶ
+      if (mounted && !_disposed) {
+        setState(() {
+          errorMessage = e.toString();
+          isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      title: Text(badgeData?.name ?? 'バッジ'),
+      content: SizedBox(
+        width: double.maxFinite,
+        height: MediaQuery.of(context).size.height * 0.5,
+        child: _buildBadgeContent(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('閉じる'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBadgeContent() {
+    if (isLoading) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 16),
+            Text(
+              task?.hasBadgeData() == true ? 'バッジを表示中...' : 'バッジを生成中...',
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              task?.hasBadgeData() == true 
+                  ? '保存されたバッジを読み込んでいます'
+                  : '画像生成のため少し時間がかかります',
+              style: const TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (errorMessage != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error, color: Colors.red, size: 48),
+            const SizedBox(height: 16),
+            const Text(
+              'エラーが発生しました',
+              style: TextStyle(
+                color: Colors.red,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              errorMessage!,
+              style: const TextStyle(color: Colors.red, fontSize: 12),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _disposed ? null : _fetchBadgeData,
+              child: const Text('再試行'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (badgeData == null) {
+      return const Center(
+        child: Text('バッジデータがありません'),
+      );
+    }
+
+    return Column(
+      children: [
+        // バッジ画像
+        Expanded(
+          flex: 2,
+          child: Container(
+            width: double.infinity,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              image: badgeData!.imageData != null
+                  ? DecorationImage(
+                      image: MemoryImage(badgeData!.imageData!),
+                      fit: BoxFit.contain,
+                    )
+                  : null,
+            ),
+            child: badgeData!.imageData == null
+                ? const Center(
+                    child: Icon(
+                      Icons.image_not_supported,
+                      size: 64,
+                      color: Colors.grey,
+                    ),
+                  )
+                : null,
+          ),
+        ),
+        const SizedBox(height: 16),
+        
+        // バッジ説明文
+        Expanded(
+          flex: 1,
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF9F9F9),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: SingleChildScrollView(
+              child: Text(
+                badgeData!.text,
+                style: const TextStyle(
+                  color: Color(0xFF1D1B20),
+                  fontSize: 14,
+                  fontWeight: FontWeight.w400,
+                  height: 1.5,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/feat/badge/badge.dart
+++ b/lib/feat/badge/badge.dart
@@ -172,29 +172,42 @@ class _TaskBadgeState extends State<TaskBadge> {
 
     return Column(
       children: [
-        // バッジ画像
+        // バッジ画像（円形）
         Expanded(
           flex: 2,
-          child: Container(
-            width: double.infinity,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(8),
-              image: badgeData!.imageData != null
-                  ? DecorationImage(
-                      image: MemoryImage(badgeData!.imageData!),
-                      fit: BoxFit.contain,
-                    )
-                  : null,
-            ),
-            child: badgeData!.imageData == null
-                ? const Center(
-                    child: Icon(
-                      Icons.image_not_supported,
-                      size: 64,
-                      color: Colors.grey,
+          child: Center(
+            child: AspectRatio(
+              aspectRatio: 1.0, // 正方形の比率
+              child: Container(
+                width: double.infinity,
+                decoration: const BoxDecoration(
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black26,
+                      blurRadius: 12,
+                      offset: Offset(0, 6),
                     ),
-                  )
-                : null,
+                  ],
+                  shape: BoxShape.circle,
+                  color: Colors.transparent, // 透明にして縁を隠す
+                ),
+                child: ClipOval(
+                  child: badgeData!.imageData != null
+                      ? Image.memory(
+                          badgeData!.imageData!,
+                          fit: BoxFit.cover, // 円形に合わせてクロップ
+                        )
+                      : Container(
+                          color: Colors.grey[200],
+                          child: const Icon(
+                            Icons.image_not_supported,
+                            size: 64,
+                            color: Colors.grey,
+                          ),
+                        ),
+                ),
+              ),
+            ),
           ),
         ),
         const SizedBox(height: 16),

--- a/lib/feat/badge/badge.dart
+++ b/lib/feat/badge/badge.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import '../../core/services/task_storage.dart';
 import '../../core/services/badge_service.dart';
 import '../../core/models/task_data.dart';
+import 'share_utils.dart';
 
 // バッジ機能ウィジェット
 class TaskBadge extends StatefulWidget {
@@ -117,6 +118,44 @@ class _TaskBadgeState extends State<TaskBadge> with SingleTickerProviderStateMix
         child: _buildBadgeContent(),
       ),
       actions: [
+        IconButton(
+          onPressed: () async {
+            try {
+              if (badgeData?.imageData != null) {
+                await shareBytesAsImage(badgeData!.imageData!, filename: '${badgeData!.name.replaceAll(" ", "_")}.png', text: badgeData!.name);
+                if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('共有シートを開きました')));
+              }
+            } catch (e) {
+              if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('共有に失敗しました: $e')));
+            }
+          },
+          icon: const Icon(Icons.share, color: Color(0xFF6750A4)),
+          tooltip: '共有',
+        ),
+        IconButton(
+          onPressed: () async {
+            try {
+              await shareToTwitter(badgeData?.name ?? '');
+              if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Twitterの画面を開きます')));
+            } catch (e) {
+              if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Twitter共有に失敗しました: $e')));
+            }
+          },
+          icon: const Icon(Icons.alternate_email, color: Color(0xFF1DA1F2)),
+          tooltip: 'Twitter',
+        ),
+        IconButton(
+          onPressed: () async {
+            try {
+              await shareToLine(badgeData?.name ?? '');
+              if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('LINEの画面を開きます')));
+            } catch (e) {
+              if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('LINE共有に失敗しました: $e')));
+            }
+          },
+          icon: const Icon(Icons.chat, color: Color(0xFF00B900)),
+          tooltip: 'LINE',
+        ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('閉じる'),

--- a/lib/feat/badge/badge_gallery.dart
+++ b/lib/feat/badge/badge_gallery.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'dart:typed_data';
+import '../../core/services/task_storage.dart';
+import '../../core/models/task_data.dart';
+import 'badge.dart';
+
+/// 取得済みバッジを一覧でプレビューするウィジェット
+class BadgeGallery extends StatefulWidget {
+  const BadgeGallery({super.key});
+
+  @override
+  State<BadgeGallery> createState() => _BadgeGalleryState();
+}
+
+class _BadgeGalleryState extends State<BadgeGallery> {
+  List<TaskData> _badgedTasks = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBadges();
+  }
+
+  void _loadBadges() {
+    final all = TaskStorage.getAllTasks();
+    setState(() {
+      _badgedTasks = all.where((t) => t.hasBadgeData()).toList();
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_badgedTasks.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.emoji_events_outlined, size: 64, color: Colors.grey),
+            SizedBox(height: 12),
+            Text('まだ取得したバッジがありません', style: TextStyle(color: Colors.grey)),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+          child: Row(
+            children: [
+              const Icon(Icons.emoji_events, color: Color(0xFF6750A4)),
+              const SizedBox(width: 8),
+              Text('取得済みバッジ (${_badgedTasks.length})', style: const TextStyle(fontWeight: FontWeight.bold)),
+              const Spacer(),
+              TextButton(
+                onPressed: () {
+                  setState(() => _loading = true);
+                  _loadBadges();
+                },
+                child: const Text('更新'),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12.0),
+            child: GridView.builder(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                mainAxisSpacing: 12,
+                crossAxisSpacing: 12,
+                childAspectRatio: 0.82,
+              ),
+              itemCount: _badgedTasks.length,
+              itemBuilder: (context, index) {
+                final task = _badgedTasks[index];
+                return _BadgeTile(
+                  task: task,
+                  onTap: () {
+                    // 詳細は既存の TaskBadge ダイアログを利用
+                    showDialog(
+                      context: context,
+                      builder: (_) => TaskBadge(taskId: task.id),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BadgeTile extends StatelessWidget {
+  final TaskData task;
+  final VoidCallback? onTap;
+
+  const _BadgeTile({required this.task, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final Uint8List? image = task.badgeImage;
+    final title = task.badgeTitle ?? 'バッジ';
+
+    return InkWell(
+      onTap: onTap,
+      child: Column(
+        children: [
+          Expanded(
+            child: AspectRatio(
+              aspectRatio: 1,
+              child: Container(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  boxShadow: [
+                    BoxShadow(color: Colors.black26, blurRadius: 6, offset: Offset(0, 4)),
+                  ],
+                ),
+                child: ClipOval(
+                  child: image != null
+                      ? Image.memory(image, fit: BoxFit.cover)
+                      : Container(
+                          color: Colors.grey[200],
+                          child: const Icon(Icons.image_not_supported, color: Colors.grey, size: 36),
+                        ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            title,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            style: const TextStyle(fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feat/badge/share_utils.dart
+++ b/lib/feat/badge/share_utils.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Uint8List を一時ファイルに書き、共有するユーティリティ
+Future<void> shareBytesAsImage(Uint8List bytes, {String? filename, String? text}) async {
+  final dir = await getTemporaryDirectory();
+  final fileName = filename ?? 'badge_${DateTime.now().millisecondsSinceEpoch}.png';
+  final file = File('${dir.path}/$fileName');
+  await file.writeAsBytes(bytes);
+
+  await Share.shareXFiles([XFile(file.path)], text: text ?? '共有されたバッジ');
+}
+
+/// テキストを Twitter の intent で開く
+Future<void> shareToTwitter(String text) async {
+  final encoded = Uri.encodeComponent(text);
+  final url = Uri.parse('https://twitter.com/intent/tweet?text=$encoded');
+  if (await canLaunchUrl(url)) {
+    await launchUrl(url, mode: LaunchMode.externalApplication);
+  } else {
+    throw 'Could not launch $url';
+  }
+}
+
+/// テキストを LINE の共有URLで開く
+Future<void> shareToLine(String text) async {
+  final encoded = Uri.encodeComponent(text);
+  final url = Uri.parse('https://social-plugins.line.me/lineit/share?text=$encoded');
+  if (await canLaunchUrl(url)) {
+    await launchUrl(url, mode: LaunchMode.externalApplication);
+  } else {
+    throw 'Could not launch $url';
+  }
+}

--- a/lib/feat/edit/task_edit.dart
+++ b/lib/feat/edit/task_edit.dart
@@ -173,6 +173,17 @@ class _TaskEditState extends State<TaskEdit> {
                   child: const Text('保存'),
                 ),
               ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () => _showDeleteConfirmationDialog(context),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.red,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('削除'),
+                ),
+              ),
             ],
           ],
         ),
@@ -362,5 +373,117 @@ class _TaskEditState extends State<TaskEdit> {
         },
       );
     });
+  }
+
+  // タスク削除確認ダイアログ
+  void _showDeleteConfirmationDialog(BuildContext context) {
+    if (_currentTask == null) return;
+
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          title: const Row(
+            children: [
+              Icon(Icons.warning, color: Colors.red, size: 24),
+              SizedBox(width: 8),
+              Text('タスクを削除'),
+            ],
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '以下のタスクを完全に削除しますか？',
+                style: TextStyle(fontSize: 16),
+              ),
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.grey[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _currentTask!.task,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '期限: ${_currentTask!.getDueDateString()}',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                    Text(
+                      'カテゴリ: ${_currentTask!.getCategoryDisplayName()}',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                '※この操作は取り消せません',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.red,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('キャンセル'),
+            ),
+            TextButton(
+              onPressed: () async {
+                try {
+                  // タスクをDBから削除
+                  await TaskStorage.deleteTask(_currentTask!.id);
+                  
+                  // ダイアログを閉じる
+                  if (context.mounted) {
+                    Navigator.of(context).pop(); // 削除確認ダイアログを閉じる
+                    Navigator.of(context).pop(true); // 編集画面を閉じて削除完了を示す
+                  }
+                } catch (e) {
+                  // エラーハンドリング
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('削除に失敗しました: $e'),
+                        backgroundColor: Colors.red,
+                        duration: const Duration(seconds: 3),
+                      ),
+                    );
+                  }
+                }
+              },
+              style: TextButton.styleFrom(
+                foregroundColor: Colors.red,
+              ),
+              child: const Text('削除'),
+            ),
+          ],
+        );
+      },
+    );
   }
 }

--- a/lib/feat/root/viewtask/viewtask.dart
+++ b/lib/feat/root/viewtask/viewtask.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:do_or_doom/feat/ai_diary/ai_diary.dart';
 import 'package:do_or_doom/feat/badge/badge.dart';
+import 'package:do_or_doom/feat/badge/badge_gallery.dart';
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
 import '../../../core/models/task_data.dart';
@@ -288,6 +289,31 @@ class TaskListWidgetState extends State<TaskListWidget> {
                       }),
                     ],
                   ),
+                ),
+                const SizedBox(width: 8),
+                // バッジギャラリーボタン
+                IconButton(
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder: (_) => Dialog(
+                        child: SizedBox(
+                          width: 600,
+                          height: 520,
+                          child: Padding(
+                            padding: const EdgeInsets.all(12.0),
+                            child: Column(
+                              children: const [
+                                Expanded(child: BadgeGallery()),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.emoji_events, color: Color(0xFF6750A4)),
+                  tooltip: 'バッジギャラリー',
                 ),
               ],
             ),

--- a/lib/feat/root/viewtask/viewtask.dart
+++ b/lib/feat/root/viewtask/viewtask.dart
@@ -798,17 +798,39 @@ class TaskItemWidget extends StatelessWidget {
   }
 
   Widget _buildSimpleButton() {
+    // タスクが完了済みかどうかを判定（完了待機中は未完了として扱う）
+    final isActuallyCompleted = task.isCompleted && !isPendingCompletion;
+    
     return Builder(
       builder: (BuildContext context) {
         return GestureDetector(
           onTap: () {
-            // スタブダイアログを表示
-            showDialog(
-              context: context,
-              builder: (BuildContext context) {
-                return AiDiary(taskId: int.parse(task.id));
-              },
-            );
+            if (isActuallyCompleted) {
+              // 完了済みタスクの場合：バッジ機能のプレースホルダー
+              showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                    title: const Text('バッジ機能'),
+                    content: const Text('バッジ機能は準備中です。'),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: const Text('閉じる'),
+                      ),
+                    ],
+                  );
+                },
+              );
+            } else {
+              // 未完了タスクの場合：AI日記機能
+              showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  return AiDiary(taskId: int.parse(task.id));
+                },
+              );
+            }
           },
           child: Container(
             width: 64,
@@ -819,10 +841,10 @@ class TaskItemWidget extends StatelessWidget {
                 borderRadius: BorderRadius.circular(16),
               ),
             ),
-            child: const Center(
+            child: Center(
               child: Text(
-                'AI日記',
-                style: TextStyle(
+                isActuallyCompleted ? 'バッジ' : 'AI日記',
+                style: const TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w500,
                   color: Color(0xFF6750A4),

--- a/lib/feat/root/viewtask/viewtask.dart
+++ b/lib/feat/root/viewtask/viewtask.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:do_or_doom/feat/ai_diary/ai_diary.dart';
+import 'package:do_or_doom/feat/badge/badge.dart';
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_calendar/calendar.dart';
 import '../../../core/models/task_data.dart';
@@ -806,20 +807,11 @@ class TaskItemWidget extends StatelessWidget {
         return GestureDetector(
           onTap: () {
             if (isActuallyCompleted) {
-              // 完了済みタスクの場合：バッジ機能のプレースホルダー
+              // 完了済みタスクの場合：バッジ機能
               showDialog(
                 context: context,
                 builder: (BuildContext context) {
-                  return AlertDialog(
-                    title: const Text('バッジ機能'),
-                    content: const Text('バッジ機能は準備中です。'),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.of(context).pop(),
-                        child: const Text('閉じる'),
-                      ),
-                    ],
-                  );
+                  return TaskBadge(taskId: int.parse(task.id));
                 },
               );
             } else {

--- a/lib/feat/root/viewtask/viewtask.dart
+++ b/lib/feat/root/viewtask/viewtask.dart
@@ -533,6 +533,139 @@ class TaskListWidgetState extends State<TaskListWidget> {
               onPressed: () => Navigator.of(context).pop(),
               child: const Text('閉じる'),
             ),
+            if (taskData != null) ...[
+              TextButton(
+                onPressed: () => _showDeleteConfirmationDialog(context, taskData!),
+                style: TextButton.styleFrom(
+                  foregroundColor: Colors.red,
+                ),
+                child: const Text('削除'),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+
+  // タスク削除確認ダイアログ
+  void _showDeleteConfirmationDialog(BuildContext context, TaskData taskData) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          title: const Row(
+            children: [
+              Icon(Icons.warning, color: Colors.red, size: 24),
+              SizedBox(width: 8),
+              Text('タスクを削除'),
+            ],
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '以下のタスクを完全に削除しますか？',
+                style: TextStyle(fontSize: 16),
+              ),
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.grey[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      taskData.task,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '期限: ${taskData.getDueDateString()}',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                    Text(
+                      'カテゴリ: ${taskData.getCategoryDisplayName()}',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                '※この操作は取り消せません',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.red,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('キャンセル'),
+            ),
+            TextButton(
+              onPressed: () async {
+                try {
+                  // タスクをDBから削除
+                  await TaskStorage.deleteTask(taskData.id);
+                  
+                  // ダイアログを閉じる
+                  if (context.mounted) {
+                    Navigator.of(context).pop(); // 削除確認ダイアログを閉じる
+                    Navigator.of(context).pop(); // タスク詳細ダイアログを閉じる
+                  }
+                  
+                  // タスクリストを再読み込み
+                  _loadTasksFromDB();
+                  
+                  // 削除完了メッセージを表示
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('「${taskData.task}」を削除しました'),
+                        backgroundColor: Colors.green,
+                        duration: const Duration(seconds: 2),
+                      ),
+                    );
+                  }
+                } catch (e) {
+                  // エラーハンドリング
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('削除に失敗しました: $e'),
+                        backgroundColor: Colors.red,
+                        duration: const Duration(seconds: 3),
+                      ),
+                    );
+                  }
+                }
+              },
+              style: TextButton.styleFrom(
+                foregroundColor: Colors.red,
+              ),
+              child: const Text('削除'),
+            ),
           ],
         );
       },

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
+import share_plus
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -189,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
@@ -221,6 +229,11 @@ packages:
     version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -396,10 +409,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.6"
   package_config:
     dependency: transitive
     description:
@@ -428,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.17"
+    version: "2.2.18"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -504,6 +517,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: b1f15232d41e9701ab2f04181f21610c36c83a12ae426b79b4bd011c567934b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "251eb156a8b5fa9ce033747d73535bf53911071f8d3b6f4f0b578505ce0d4496"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   shelf:
     dependency: transitive
     description:
@@ -549,6 +578,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -585,34 +622,34 @@ packages:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_calendar
-      sha256: "818315ede529831f04e067ce8e2a64d17fd442a4945d8f37b83142e46ddbf8cd"
+      sha256: "8e8a4eef01d6a82ae2c17e76d497ff289ded274de014c9f471ffabc12d1e2e71"
       url: "https://pub.dev"
     source: hosted
-    version: "30.2.6"
+    version: "30.2.7"
   syncfusion_flutter_core:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_core
-      sha256: "6b8b8cb5b4647e6a5858d47fceda9b7e5a9a2be57cff28120acb65edbd92a48c"
+      sha256: bfd026c0f9822b49ff26fed11cd3334519acb6a6ad4b0c81d9cd18df6af1c4c0
       url: "https://pub.dev"
     source: hosted
-    version: "30.2.6"
+    version: "30.2.7"
   syncfusion_flutter_datepicker:
     dependency: transitive
     description:
       name: syncfusion_flutter_datepicker
-      sha256: "873038041c87626bb0d1ea40ab43e881d18781120a4d11922d9a69efc9147a5b"
+      sha256: b5f35cc808e91b229d41613efe71dadab1549a35bfd493f922fc06ccc2fe908c
       url: "https://pub.dev"
     source: hosted
-    version: "30.2.6"
+    version: "30.2.7"
   syncfusion_localizations:
     dependency: transitive
     description:
       name: syncfusion_localizations
-      sha256: e277b07b1e6cad2b9e500c541492160d677d0f18d18097f9132f77ff869a58b6
+      sha256: bb32b07879b4c1dee5d4c8ad1c57343a4fdae55d65a87f492727c11b68f23164
       url: "https://pub.dev"
     source: hosted
-    version: "30.2.6"
+    version: "30.2.7"
   term_glyph:
     dependency: transitive
     description:
@@ -653,6 +690,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "69ee86740f2847b9a4ba6cffa74ed12ce500bbe2b07f3dc1e643439da60637b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.18"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.4"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.3"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -701,6 +810,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  win32:
+    dependency: "direct overridden"
+    description:
+      name: win32
+      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.14.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,11 @@ dependencies:
     hive_flutter: ^1.1.0
     path_provider: ^2.1.3
     http: ^1.1.0
+    share_plus: ^6.3.0
+    url_launcher: ^6.1.10
+
+dependency_overrides:
+    win32: ^5.14.0
 
 dev_dependencies:
     flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Closes #16 
- タスク一覧画面の「完了済み」画面で、「AI日記」ボタンの代わりに「バッジ」ボタンを設置
- そのタスクを初回完了するとサーバーにリクエストが飛び、バッジ、文章、タイトルを生成
- バッジボタンで生成した3つを確認可能
- バッジが自動でゆっくり裏面を見せるような方向に回転
- バッジ確認画面で、共有ボタンを設置(普通の共有、Line、X)